### PR TITLE
feat(persistence): 实现数据库热更新交接机制

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ plugins:
 
 默认同步模式会在 `usage.handle` 返回前提交每条统计，避免正常记录停留在未刷盘窗口。仅当显式设置 `sync_on_record: false` 时启用批量模式；进程被强制终止时，批量模式最多可能损失一个 `flush_interval` 或未达到 `flush_max_records` 的窗口。
 
+插件会在数据库旁创建 `<data_path>.handover` 协调同一 CLIProxyAPI 进程中的热更新。新版实例注册时，旧版实例会先刷盘并释放 bbolt 独占锁，再由新版实例接管数据库，从而避免 `open database: timeout`。从不支持此交接机制的旧版本首次升级时，需要先重启 CLIProxyAPI 或删除后重装一次；之后的版本更新可以直接热更新。
+
 修改 `data_path` 会切换到一个独立数据库，不会自动迁移或删除旧文件。
 
 ## 页面与接口
@@ -262,6 +264,8 @@ plugins:
 | `sync_on_record` | `true` | Commits each record before acknowledgement by default; set to `false` to enable higher-throughput batching |
 
 The default synchronous mode commits each statistic before `usage.handle` returns, avoiding an unflushed normal-operation window. Batching is enabled only when `sync_on_record: false` is set explicitly; if the process is forcefully terminated in batch mode, up to one `flush_interval` or unflushed `flush_max_records` window may be lost.
+
+The plugin creates `<data_path>.handover` next to the database to coordinate hot reloads within the same CLIProxyAPI process. When a replacement instance registers, the retired instance flushes and releases bbolt's exclusive lock before the replacement takes ownership, preventing `open database: timeout`. The first upgrade from a version without this handover mechanism still requires one CLIProxyAPI restart or one uninstall/reinstall; later upgrades can be hot reloaded directly.
 
 Changing `data_path` switches to a separate database; the old file is not automatically migrated or deleted.
 

--- a/handover.go
+++ b/handover.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	// Probe briefly first so normal startup and a clean shutdown do not create an
+	// unnecessary handover request. A longer retry follows only when bbolt reports
+	// that another plugin instance still owns its exclusive file lock.
+	storeOpenProbeTimeout    = 100 * time.Millisecond
+	storeOpenHandoverTimeout = 5 * time.Second
+	storeLeasePollInterval   = 50 * time.Millisecond
+)
+
+type storeLease struct {
+	path  string
+	token string
+	pid   int
+}
+
+func openStoreDatabase(path string) (*bolt.DB, *storeLease, error) {
+	lease, err := newStoreLease(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Most opens happen at process startup or after an orderly shutdown and can
+	// acquire the database immediately. Do not disturb a live owner unless the
+	// bbolt lock probe actually times out.
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: storeOpenProbeTimeout})
+	if err == nil {
+		if err = lease.claim(); err != nil {
+			_ = db.Close()
+			return nil, nil, err
+		}
+		return db, lease, nil
+	}
+	if !errors.Is(err, bolt.ErrTimeout) {
+		return nil, nil, err
+	}
+
+	// CLIProxyAPI loads and registers a versioned replacement while the previous
+	// shared library remains active. The old plugin therefore still owns bbolt's exclusive
+	// lock while the new plugin is registering. Publishing a new lease token asks
+	// a handover-aware old instance to flush, close, and release that lock.
+	if err = lease.claim(); err != nil {
+		return nil, nil, err
+	}
+	db, err = bolt.Open(path, 0o600, &bolt.Options{Timeout: storeOpenHandoverTimeout})
+	if err != nil {
+		lease.release()
+		return nil, nil, fmt.Errorf("hot-reload handover timed out; restart CLIProxyAPI or reinstall once when upgrading from a legacy plugin: %w", err)
+	}
+	if !lease.current() {
+		_ = db.Close()
+		return nil, nil, fmt.Errorf("database handover was superseded by another plugin instance")
+	}
+	return db, lease, nil
+}
+
+func newStoreLease(databasePath string) (*storeLease, error) {
+	var random [16]byte
+	if _, err := rand.Read(random[:]); err != nil {
+		return nil, fmt.Errorf("create database handover token: %w", err)
+	}
+	pid := os.Getpid()
+	return &storeLease{
+		path:  databasePath + ".handover",
+		token: fmt.Sprintf("%d-%s", pid, hex.EncodeToString(random[:])),
+		pid:   pid,
+	}, nil
+}
+
+func (l *storeLease) claim() error {
+	if l == nil {
+		return errors.New("database handover lease is nil")
+	}
+	if err := os.WriteFile(l.path, []byte(l.token+"\n"), 0o600); err != nil {
+		return fmt.Errorf("write database handover marker: %w", err)
+	}
+	return nil
+}
+
+func (l *storeLease) current() bool {
+	if l == nil {
+		return false
+	}
+	token, err := readStoreLeaseToken(l.path)
+	return err == nil && token == l.token
+}
+
+func (l *storeLease) release() {
+	if l == nil || !l.current() {
+		return
+	}
+	_ = os.Remove(l.path)
+}
+
+func readStoreLeaseToken(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(raw)), nil
+}
+
+func storeLeaseTokenPID(token string) (int, bool) {
+	rawPID, _, ok := strings.Cut(token, "-")
+	if !ok {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(rawPID)
+	return pid, err == nil && pid > 0
+}
+
+func (l *storeLease) monitor(store *Store) {
+	if l == nil || store == nil {
+		return
+	}
+	ticker := time.NewTicker(storeLeasePollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-store.done:
+			return
+		case <-ticker.C:
+			token, err := readStoreLeaseToken(l.path)
+			if err != nil || token == "" || token == l.token {
+				continue
+			}
+			claimPID, ok := storeLeaseTokenPID(token)
+			if !ok || claimPID != l.pid {
+				// Only instances loaded by this CLIProxyAPI process participate in
+				// hot-reload handover. A different process must still respect
+				// bbolt's normal exclusive-lock timeout.
+				continue
+			}
+			// A newer plugin instance is waiting for the database. Close through
+			// the normal actor path so pending records are flushed before bbolt's
+			// file lock is released.
+			_ = store.Close()
+			return
+		}
+	}
+}

--- a/handover_test.go
+++ b/handover_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestOpenStoreHandsDatabaseToNewPluginInstance(t *testing.T) {
+	config := testConfig(t)
+	config.SyncOnRecord = true
+	first, err := openStore(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+
+	usage := normalizedUsage{
+		Dimensions:  Dimensions{Provider: "provider", Model: "model"},
+		RequestedAt: time.Now().UTC(),
+		Counters:    Counters{Requests: 1, TotalTokens: 17},
+	}
+	if err := first.Record(usage); err != nil {
+		t.Fatal(err)
+	}
+
+	started := time.Now()
+	second, err := openStore(config)
+	if err != nil {
+		t.Fatalf("open replacement store: %v", err)
+	}
+	defer second.Close()
+	if elapsed := time.Since(started); elapsed >= storeOpenHandoverTimeout {
+		t.Fatalf("database handover took %v", elapsed)
+	}
+
+	if _, err := first.Query("retention"); err == nil || err.Error() != "store is closed" {
+		t.Fatalf("retired store query error = %v, want store is closed", err)
+	}
+	stats, err := second.Query("retention")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.Summary.Requests != 1 || stats.Summary.TotalTokens != 17 {
+		t.Fatalf("replacement store lost persisted usage: %+v", stats.Summary)
+	}
+	if second.lease == nil || !second.lease.current() {
+		t.Fatal("replacement store does not own the handover lease")
+	}
+}

--- a/persistence.go
+++ b/persistence.go
@@ -112,6 +112,7 @@ type closeCommand struct{ resp chan error }
 
 type Store struct {
 	db           *bolt.DB
+	lease        *storeLease
 	commands     chan any
 	done         chan struct{}
 	closeOnce    sync.Once
@@ -149,7 +150,7 @@ func openStore(config Config) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(config.DataPath), 0o700); err != nil {
 		return nil, fmt.Errorf("create data directory: %w", err)
 	}
-	db, err := bolt.Open(config.DataPath, 0o600, &bolt.Options{Timeout: 2 * time.Second})
+	db, lease, err := openStoreDatabase(config.DataPath)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
@@ -163,17 +164,20 @@ func openStore(config Config) (*Store, error) {
 	}
 	if err := actor.initialize(); err != nil {
 		_ = db.Close()
+		lease.release()
 		return nil, err
 	}
 
 	store := &Store{
 		db:          db,
+		lease:       lease,
 		commands:    make(chan any, 256),
 		done:        make(chan struct{}),
 		costCache:   make(map[costCacheKey]CostResponse),
 		costFlights: make(map[costCacheKey]*costFlight),
 	}
 	go store.run(actor)
+	go lease.monitor(store)
 	return store, nil
 }
 
@@ -319,6 +323,9 @@ func (s *Store) Close() error {
 		s.stateMu.Unlock()
 		s.closeErr = <-resp
 		<-s.done
+		if s.lease != nil {
+			s.lease.release()
+		}
 	})
 	return s.closeErr
 }

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -254,13 +254,20 @@ func TestStoreSyncOnRecord(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lockedConfig := config
-	lockedConfig.DataPath = config.DataPath
-	if _, err := openStore(lockedConfig); err == nil {
-		t.Fatal("expected locked database open to fail")
+	replacement, err := openStore(config)
+	if err != nil {
+		t.Fatalf("open replacement store: %v", err)
 	}
-	if err := store.Close(); err != nil {
+	defer replacement.Close()
+	if _, err := store.Query("retention"); err == nil || err.Error() != "store is closed" {
+		t.Fatalf("retired store query error = %v, want store is closed", err)
+	}
+	stats, err := replacement.Query("retention")
+	if err != nil {
 		t.Fatal(err)
+	}
+	if stats.Summary.Requests != 1 || stats.Summary.TotalTokens != 7 {
+		t.Fatalf("synchronous record was not preserved across handover: %+v", stats.Summary)
 	}
 }
 


### PR DESCRIPTION
- 添加 storeLease 结构管理数据库独占锁的协调
- 实现 openStoreDatabase 函数支持热更新时的数据库交接
- 在 persistence.go 中集成 lease 管理和监控逻辑
- 添加 .handover 文件用于同一进程内的热重载协调
- 实现 monitor 方法检测新实例并主动释放锁
- 更新 README.md 文档说明热更新交接机制
- 添加完整的单元测试验证热更新功能