### PR TITLE
docs(readme): 添加访问计数徽章

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CAP Token Usage Tracker
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![访问计数](https://count.getloli.com/get/@cap-token-usage-tracker?theme=gelbooru)](https://github.com/journey-ad/Moe-Counter)
 
 **[English](#english)** | [中文](#中文)
 


### PR DESCRIPTION
- 在 README.md 中添加了访问计数徽章
- 集成 Moe-Counter 访问统计功能
- 添加徽章链接指向项目 GitHub 页面